### PR TITLE
      partial update to better support the new "Encore" default Spotify look

### DIFF
--- a/catppuccin-frappe/user.css
+++ b/catppuccin-frappe/user.css
@@ -36,6 +36,20 @@
   --rosewater: #f2d5cf;
 }
 
+/* new search bar and top buttons / profile picture */
+.nav-alt .x-searchInput-searchInputInput,.main-topBar-button{
+    background-color: var(--spice-main);
+}
+/* New search bar hover, for some reason .main-topBar-button:hover does NOT like to work :/ maybe someone else can fix it */
+.nav-alt .x-searchInput-searchInputInput:hover{
+    background-color: var(--spice-main);
+}
+/* Disable shadow below devider from liked songs to playlists*/
+.main-rootlist-rootlistDividerContainer{
+    opacity: 0;
+}
+
+
 /* Buttons */
 .main-playButton-PlayButton.main-playButton-primary {
     color: var(--spice-player);

--- a/catppuccin-latte/user.css
+++ b/catppuccin-latte/user.css
@@ -36,9 +36,19 @@
   --rosewater: #dc8a78;
 }
 
-/* * { */
-/*     color: var(--text); */
-/* } */
+/* new search bar and top buttons / profile picture */
+.nav-alt .x-searchInput-searchInputInput,.main-topBar-button{
+    background-color: var(--spice-main);
+}
+/* New search bar hover, for some reason .main-topBar-button:hover does NOT like to work :/ maybe someone else can fix it */
+.nav-alt .x-searchInput-searchInputInput:hover{
+    background-color: var(--spice-main);
+}
+/* Disable shadow below devider from liked songs to playlists*/
+.main-rootlist-rootlistDividerContainer{
+    opacity: 0;
+}
+
 
 .button {
   color: var(--text);

--- a/catppuccin-macchiato/user.css
+++ b/catppuccin-macchiato/user.css
@@ -35,7 +35,19 @@
   --text: #cad3f5;
   --lavender: #b7bdf8;
   --rosewater: #f4dbd6;
- 
+}
+
+/* new search bar and top buttons / profile picture */
+.nav-alt .x-searchInput-searchInputInput,.main-topBar-button{
+    background-color: var(--spice-main);
+}
+/* New search bar hover, for some reason .main-topBar-button:hover does NOT like to work :/ maybe someone else can fix it */
+.nav-alt .x-searchInput-searchInputInput:hover{
+    background-color: var(--spice-main);
+}
+/* Disable shadow below devider from liked songs to playlists*/
+.main-rootlist-rootlistDividerContainer{
+    opacity: 0;
 }
 
 /* Buttons */

--- a/catppuccin-mocha/user.css
+++ b/catppuccin-mocha/user.css
@@ -36,6 +36,20 @@
   --rosewater: #f5e0dc;
 }
 
+/* new search bar and top buttons / profile picture */
+.nav-alt .x-searchInput-searchInputInput,.main-topBar-button{
+    background-color: var(--spice-main);
+}
+/* New search bar hover, for some reason .main-topBar-button:hover does NOT like to work :/ maybe someone else can fix it */
+.nav-alt .x-searchInput-searchInputInput:hover{
+    background-color: var(--spice-main);
+}
+/* Disable shadow below devider from liked songs to playlists*/
+.main-rootlist-rootlistDividerContainer{
+    opacity: 0;
+}
+
+
 /* Buttons */
 .main-playButton-PlayButton.main-playButton-primary {
     color: var(--spice-player);


### PR DESCRIPTION
Updated a small change to each of the 4 themes to better support the new "Encore" Spotify theme as followed,

-  New search bar and search bar hover
-  New top buttons (can't seem to get the hover to work) 
<img width="1211" alt="image" src="https://user-images.githubusercontent.com/31026406/195449242-6b579c1e-0272-4b18-86b8-8a5de5a79ee0.png">

-  Removed a shadow between the "Liked songs" button and the playlists
<details>
  <summary>Preview of change</summary>

Before Change
<img width="227" alt="image" src="https://user-images.githubusercontent.com/31026406/195450082-37abbf47-0b69-4e0d-a524-36c03ab16d34.png">

After Change
<img width="187" alt="image" src="https://user-images.githubusercontent.com/31026406/195449888-6a1e8ecd-9d83-4e7e-934b-bcb937f54021.png">
</details>


Example of hover NOT working on the new top buttons. Tried `.main-topBar-button:hover` to no luck.
<img width="122" alt="image" src="https://user-images.githubusercontent.com/31026406/195450208-fcea54c6-0fe9-49bc-94de-8191940913cc.png"> 
though it does on the search bar `.nav-alt .x-searchInput-searchInputInput:hover`
<img width="352" alt="image" src="https://user-images.githubusercontent.com/31026406/195450280-d5338fe2-c61d-41d1-b816-729ebb137d61.png">

also, the JS scripts included for each theme seem to not allow these changes to apply though I'm not sure why.
