### PR TITLE
fix(topbar): support both topbar structures

### DIFF
--- a/catppuccin/src/_top_bar.scss
+++ b/catppuccin/src/_top_bar.scss
@@ -1,4 +1,5 @@
-:root .Root__top-bar header {
+:root .Root__top-bar header,
+:root .main-topBar-container {
   // Normalize button hover effect
   button:not(.x-searchInput-searchInputClearButton),
   .main-topBar-button {
@@ -19,7 +20,7 @@
     color: var(--spice-player);
   }
 
-  // Search bar 
+  // Search bar
   .x-searchInput-searchInputInput {
     background-color: var(--spice-overlay0);
     color: var(--spice-subtext) !important;


### PR DESCRIPTION
as of spotify 1.2.23 they now use a different topbar structure placing it inside main view and not its own grid
to fix this without pulling support to the older versions i will not remove the topbar sass module completely, instead adding a secondary parent selector.