### PR TITLE
fix(css): equalizer #80,header background #81

### DIFF
--- a/catppuccin/app.scss
+++ b/catppuccin/app.scss
@@ -22,14 +22,14 @@
     background-color: var(--spice-surface0);
     color: var(--spice-subtext);
     transition: all 0.2s ease;
-    
+
     &:focus {
       background-color: var(--spice-surface1);
       color: var(--spice-text);
       outline: 2px solid var(--spice-overlay1);
       outline-offset: 1px;
     }
-    
+
     &::placeholder {
       color: var(--spice-overlay0);
       transition: color 0.2s ease;
@@ -40,12 +40,12 @@
     color: var(--spice-text);
     background-color: var(--spice-surface0);
     transition: all 0.2s ease;
-    
+
     &:hover:not(:disabled) {
       background-color: var(--spice-surface1);
       cursor: pointer;
     }
-    
+
     &:focus {
       outline: 2px solid var(--spice-overlay1);
       outline-offset: 1px;
@@ -76,7 +76,7 @@
   input:checked:hover:not([disabled], :active)~.x-toggle-indicatorWrapper {
     background-color: var(--spice-overlay0);
   }
-  
+
   input:focus-visible~.x-toggle-indicatorWrapper {
     outline: 2px solid var(--spice-overlay1);
     outline-offset: 2px;
@@ -92,15 +92,11 @@
   }
 
   .main-trackList-playingIcon {
-    background-size: cover;
-    padding-left: 100%;
-    background-image: var(--spice-equalizer);
+    content: var(--spice-equalizer);
   }
 
-  .view-homeShortcutsGrid-equaliser {
-    background-image: var(--spice-equalizer);
-    background-size: cover;
-    padding-left: 35%;
+  .view-homeShortcutsGrid-equaliserImage {
+    content: var(--spice-equalizer);
   }
 
   // Scrollbars

--- a/catppuccin/theme.js
+++ b/catppuccin/theme.js
@@ -41,6 +41,7 @@
 
     Spicetify.React.useEffect(() => {
       const accent = selectedValue === "none" ? "text" : selectedValue;
+      console.log(accent)
       const properties = {
         "--spice-text": `var(--spice-${selectedValue})`,
         "--spice-button-active": `var(--spice-${selectedValue})`,
@@ -48,7 +49,7 @@
           "body > script.marketplaceScript"
         )
           ? `url('https://github.com/catppuccin/spicetify/blob/main/catppuccin/assets/${colorScheme}/equalizer-animated-${accent}.gif?raw=true')`
-          : `url('${colorScheme}/equalizer-animated-${accent}.gif')`,
+          : `url('assets/${colorScheme}/equalizer-animated-${accent}.gif')`,
       };
 
       Object.entries(properties).forEach(([property, value]) => {

--- a/catppuccin/user.css
+++ b/catppuccin/user.css
@@ -217,14 +217,10 @@
   color: var(--spice-subtext) !important;
 }
 :root .main-trackList-playingIcon {
-  background-size: cover;
-  padding-left: 100%;
-  background-image: var(--spice-equalizer);
+  content: var(--spice-equalizer);
 }
-:root .view-homeShortcutsGrid-equaliser {
-  background-image: var(--spice-equalizer);
-  background-size: cover;
-  padding-left: 35%;
+:root .view-homeShortcutsGrid-equaliserImage {
+  content: var(--spice-equalizer);
 }
 :root .os-scrollbar-track,
 :root ::-webkit-scrollbar {
@@ -251,4 +247,11 @@
 :root .main-contextMenu-menuItemButton:hover,
 :root .main-contextMenu-menuItemButton:not([aria-checked=true]):focus {
   color: var(--spice-subtext);
+}
+:root .main-home-filterChipsSection {
+    background-color: var(--spice-main);
+}
+
+:root .main-home-filterChipsSection::after {
+    background-color: transparent;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Catppuccin",
+    "name": "Catppuccin-Fork",
     "description": "Maintained fork of Catpcuccin",
     "preview": "assets/catppuccin-latte.webp",
     "readme": "README.md",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Catppuccin-Test",
+    "name": "Catppuccin",
     "description": "Maintained fork of Catpcuccin",
     "preview": "assets/catppuccin-latte.webp",
     "readme": "README.md",

--- a/manifest.json
+++ b/manifest.json
@@ -1,16 +1,17 @@
 [
   {
     "name": "Catppuccin",
-    "description": "Official Catppuccin Theme for Spotify",
+    "description": "Maintained fork of Catpcuccin",
     "preview": "assets/catppuccin-latte.webp",
     "readme": "README.md",
     "usercss": "catppuccin/user.css",
     "schemes": "catppuccin/color.ini",
     "include": [
-      "https://raw.githubusercontent.com/catppuccin/spicetify/main/catppuccin/theme.js"
+      "https://raw.githubusercontent.com/KamilWachnicki/spicetify-catpuccin/refs/heads/main/catppuccin/theme.js"
     ],
+    "assets": "catppuccin/assets"
     "authors": [
-      { "name": "Catppuccin Org", "url": "https://github.com/catppuccin" }
+      { "name": "Kamil Wachnicki", "url": "https://github.com/catppuccin" }
     ],
     "tags": ["official", "palette"]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "include": [
       "https://raw.githubusercontent.com/KamilWachnicki/spicetify-catpuccin/refs/heads/main/catppuccin/theme.js"
     ],
-    "assets": "catppuccin/assets"
+    "assets": "catppuccin/assets",
     "authors": [
       { "name": "Cattpuccin Org", "url": "https://github.com/catppuccin" }
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Catppuccin-Fork",
+    "name": "Catppuccin-Test",
     "description": "Maintained fork of Catpcuccin",
     "preview": "assets/catppuccin-latte.webp",
     "readme": "README.md",
@@ -11,8 +11,8 @@
     ],
     "assets": "catppuccin/assets"
     "authors": [
-      { "name": "Kamil Wachnicki", "url": "https://github.com/catppuccin" }
+      { "name": "Cattpuccin Org", "url": "https://github.com/catppuccin" }
     ],
-    "tags": ["official", "palette"]
+    "tags": ["palette"]
   }
 ]


### PR DESCRIPTION
Tested locally, .main-trackList-playingIcon class works but the spicetify-cli css-map is outdated and has not mapped the new POVCTaiu08g8SWXr class to it.

<img width="290" height="266" alt="image" src="https://github.com/user-attachments/assets/ce0a034b-445f-4b73-9426-384df823b7ee" />
<img width="1461" height="277" alt="image" src="https://github.com/user-attachments/assets/6726222e-88ac-4f74-a573-e02fafa25864" />
<img width="345" height="85" alt="image" src="https://github.com/user-attachments/assets/c4abd598-023d-41c1-aefb-b12f0ce6dbe7" />
